### PR TITLE
Fix for Canvas.rows() output being 1 row/col too large when Canvas::new() is passed particular values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@
 //!     canvas.set(5, 4);
 //!     canvas.line(2, 2, 8, 8);
 //!     assert_eq!(canvas.frame(), [
-//! " ⢄    ",
-//! "  ⠙⢄  ",
-//! "    ⠁ "].join("\n"));
+//! " ⢄   ",
+//! "  ⠙⢄ ",
+//! "    ⠁"].join("\n"));
 //! }
 //! ```
 use std::char;
@@ -67,7 +67,6 @@ impl Canvas {
         if self.height < col + 1 {
             self.height = col + 1;
         }
-    }
     }
 
     /// Clears the canvas.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,8 @@ impl Canvas {
     /// Note that each row is actually four pixels high due to the fact that a single Braille
     /// character spans two by four pixels.
     pub fn rows(&self) -> Vec<String> {
-        let mut maxrow = self.width;
-        let mut maxcol = self.height;
+        let mut maxrow = if self.width > 0 { self.width - 1 } else { 0 };
+        let mut maxcol = if self.height > 0 { self.height - 1 } else { 0 };
         for &(x, y) in self.chars.keys() {
             if x > maxrow {
                 maxrow = x;


### PR DESCRIPTION
I had made a Pull Request on [/ftxqxd/drawille-rs](https://github.com/ftxqxd/drawille-rs), but noticed this fork and the issue where you were given ownership, so I thought I'd bring the Pull Request here as well.

This change could potentially be partially breaking (may alter output slightly) if a user relied on the potential empty margin that could appear on the bottom and right of the Canvas.

---
What is it?
--
Fixes ftxqxd/drawille-rs#14, where output string can be 1 row and/or col too large resulting in additional white space when given width is divisible by 2 and/or height is divisible by 4.

The only time this issue occurs is when `Canvas::new()` is called and the given width/height are divisible by the _'braille-pixel'_ ratio, where width is divisible by 2 and height by 4. For example if a width of 12 is given, the Canvas struct's `width` would be 6 and when `rows()` is called, the `maxrow` variable would be off by one and cause an additional empty column to appear in the output string. Another example, if a height of 4 is given, the Canvas' `height` would be 1 and when `rows()` is called, the `maxcol` variable would be set to 1, allowing the loop to run an additional iteration and inserting an empty row in the output string.

Prior to this fix, the following code:
```rust
let mut canvas = Canvas::new(2, 4);
for y in 0..4 {
    for x in 0..2 {
        canvas.set(x, y);
    }
}
dbg!(canvas.frame());
```
Would output the following:
```
[examples\test_canvas_properties.rs:14] canvas.frame() = "⣿ \n  "
```
And with the fix the output is instead:
```
[examples\test_canvas_properties.rs:14] canvas.frame() = "⣿"
```
---
What's the fix?
--
A fix for this issue would be to instead dynamically update the `width` and `height` member fields of Canvas whenever it is modified, with for example a `check_bounds(u16,u16)`:
```rust
fn check_bounds(&mut self, row: u16, col: u16) {
   if self.width < row + 1 {
      self.width = row + 1;
   }
   if self.height < col + 1 {
      self.height = col + 1;
   }
}
```

And to also properly calculate the Canvas width and height in the constructor:
```rust
pub fn new(width: u32, height: u32) -> Canvas {
   let width_adjustment: u16 = if width != 0 && width % 2 == 0 { 0 } else { 1 };
   let height_adjustment: u16 = if height != 0 && height % 4 == 0 { 0 } else { 1 };
   Canvas {
      chars: FnvHashMap::default(),
      width: (width / 2) as u16 + width_adjustment,
      height: (height / 4) as u16 + height_adjustment,
   }
}
```

With these changes, the bounds checking for loop in Canvas.rows() can be removed and the loop ranges become exclusive rather than inclusive:
```rust
pub fn rows(&self) -> Vec<String> {
   let maxrow = self.width;
   let maxcol = self.height;

   let mut result = Vec::with_capacity(maxcol as usize + 1);
   for y in 0..maxcol {
      let mut row = String::with_capacity(maxrow as usize + 1);
      for x in 0..maxrow {
   // -- snip --
}
```

I could also include `Canvas.get_width()` and `Canvas.get_height()` additions if you wish, however you do have another Pull Request which has `Canvas.width()` and `Canvas.height()`, so that's up to you.

Let me know if I could do anything or if there's an issue with this Pull Request. Thanks!